### PR TITLE
substitued countnz for count.

### DIFF
--- a/src/SimplePosets.jl
+++ b/src/SimplePosets.jl
@@ -68,7 +68,7 @@ function check(P::SimplePoset)
 
     # transitive closure check
     Z = zeta_matrix(P)
-    if countnz(Z) != countnz(Z*Z)
+    if count(iszero,Z) != count(iszero,Z*Z)
         warn("Not transitively closed")
         return false
     end


### PR DESCRIPTION
When using `check` I found out that it uses the deprecated function `countnz`.
It was successfully substituted by `count`.