### PR TITLE
Add the ability to get a linear extension without doing a `deepcopy`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SimplePosets"
 uuid = "b2aef97b-4721-5af9-b440-0bad754dc5ba"
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 FlexLinearAlgebra = "b67e1e5a-d13e-5892-ad81-fb75f5903773"

--- a/src/linear_extensions.jl
+++ b/src/linear_extensions.jl
@@ -1,14 +1,23 @@
 # Experimental functions for linear extensions
 
-export linear_extension, all_linear_extensions, random_linear_extension
+export linear_extension, linear_extension_empty!, all_linear_extensions, random_linear_extension
 
 
 """
 `linear_extension(P)` returns a linear extension of the poset `P`.
 """
 function linear_extension(P::SimplePoset{T}) where T
-    result = T[]
     PP = deepcopy(P)
+    result = linear_extension_empty!(PP)
+    return result
+end
+
+"""
+`linear_extension_empty!(P)` returns a linear extension of the poset `P`,
+but also empties the poset `P`. This is a destructive operation.
+"""
+function linear_extension_empty!(PP::SimplePoset{T}) where T
+    result = T[]
     while card(PP)>0
         M = minimals(PP)
         append!(result, M)


### PR DESCRIPTION
This pull request adds the `linear_extension_empty!(PP::SimplePoset)` function, which returns a linear extension of `PP`, but also empties `PP`.

The behavior of the existing `linear_extension` function will remain the same.

### Motivation

I need to get linear extensions, but in my use case, the `deepcopy` statement in `linear_extension` breaks my ability to compare elements in the linear extension to my original elements.

For example, suppose I have this:
```julia
struct Foo
x::Dict{Any, Any}
end
```

If I construct a poset containing `Foo`s, and then I use `linear_extension`, the `Foo`s in the resulting linear extension are not equal to my original `Foo`s.

cc: @scheinerman 