### PR TITLE
Fix `[compat]` entries in `Project.toml`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,10 +10,10 @@ SimplePartitions = "ec83eff0-a5b5-5643-ae32-5cbf6eedec9d"
 
 [compat]
 julia = "1"
-FlexLinearAlgebra = "0"
-Primes = "0"
-SimpleGraphs = "0"
-SimplePartitions = "0"
+FlexLinearAlgebra = "0.0.2, 0.0.3, 0.1.0"
+Primes = "0.4, 0.5"
+SimpleGraphs = "0.2, 0.3, 0.4, 0.5, 0.6"
+SimplePartitions = "0.0.1, 0.1, 0.2, 0.3"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
In the General registry, we now **strongly** discourage users from having `[compat]` entries of the form:
```toml
SomePackage = "0"
```

These `[compat]` entries are problematic because they include an infinite number of breaking releases.

This pull request fixes the `[compat]` entries in the `Project.toml` file for this package.

cc: @scheinerman